### PR TITLE
healthd: allow home(page) button to wake

### DIFF
--- a/healthd/healthd_mode_charger.cpp
+++ b/healthd/healthd_mode_charger.cpp
@@ -460,7 +460,7 @@ static void set_next_key_check(charger* charger, key_state* key, int64_t timeout
 static void process_key(charger* charger, int code, int64_t now) {
     key_state* key = &charger->keys[code];
 
-    if (code == KEY_POWER) {
+    if (code == KEY_POWER || code == KEY_HOME || code == KEY_HOMEPAGE) {
         if (key->down) {
             int64_t reboot_timeout = key->timestamp + POWER_ON_KEY_TIME;
             if (now >= reboot_timeout) {
@@ -507,6 +507,8 @@ static void process_key(charger* charger, int code, int64_t now) {
 
 static void handle_input_state(charger* charger, int64_t now) {
     process_key(charger, KEY_POWER, now);
+    process_key(charger, KEY_HOME, now);
+    process_key(charger, KEY_HOMEPAGE, now);
 
     if (charger->next_key_check != -1 && now > charger->next_key_check)
         charger->next_key_check = -1;


### PR DESCRIPTION
Based on sub77-du 0001-healthd-allow-home-page-button-to-wake.patch https://github.com/sub77-du/vendor_extra/blob/e98f5313d73c37d29c10b68b06c8f500f7f69037/patch/device/matissewifi/system_core/0001-healthd-allow-home-page-button-to-wake.patch

Change-Id: If31efba54b631f57a4843ded1950b933c94fe8f2